### PR TITLE
Feat: FCM PUSH 기능 구현 (Token 및 firebase key 필요)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,15 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.hibernate:hibernate-core:5.6.15.Final'
+
+    implementation 'com.google.firebase:firebase-admin:9.2.0'               // Google Firebase Admin
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'         // Jackson Data Bind
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.13.0' // Google auth library
+
+    implementation 'org.slf4j:slf4j-api:2.0.0'
+    implementation 'ch.qos.logback:logback-classic:1.4.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/estsoft/projectdose/fcm/controller/FcmController.java
+++ b/src/main/java/com/estsoft/projectdose/fcm/controller/FcmController.java
@@ -28,7 +28,7 @@ public class FcmController {
 		this.fcmService = fcmService;
 	}
 
-	@PostMapping("/api/v1/fcm/sendMessage")
+	@PostMapping("/sendMessage")
 	public ResponseEntity<ApiResponseWrapper<Object>> pushMessage(@RequestBody @Validated FcmSendDto fcmSendDto)
 		throws IOException {
 		log.debug("[+] 푸시 메시지를 전송합니다. ");

--- a/src/main/java/com/estsoft/projectdose/fcm/controller/FcmController.java
+++ b/src/main/java/com/estsoft/projectdose/fcm/controller/FcmController.java
@@ -1,0 +1,45 @@
+package com.estsoft.projectdose.fcm.controller;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.estsoft.projectdose.fcm.dto.ApiResponseWrapper;
+import com.estsoft.projectdose.fcm.dto.FcmSendDto;
+import com.estsoft.projectdose.fcm.dto.SuccessCode;
+import com.estsoft.projectdose.fcm.service.FcmService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/fcm")
+public class FcmController {
+
+	private final FcmService fcmService;
+
+	public FcmController(FcmService fcmService) {
+		this.fcmService = fcmService;
+	}
+
+	@PostMapping("/api/v1/fcm/sendMessage")
+	public ResponseEntity<ApiResponseWrapper<Object>> pushMessage(@RequestBody @Validated FcmSendDto fcmSendDto)
+		throws IOException {
+		log.debug("[+] 푸시 메시지를 전송합니다. ");
+		int result = fcmService.sendMessageTo(fcmSendDto);
+
+		ApiResponseWrapper<Object> arw = ApiResponseWrapper
+			.builder()
+			.result(result)
+			.resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
+			.resultMsg(SuccessCode.SELECT_SUCCESS.getMessage())
+			.build();
+		return new ResponseEntity<>(arw, HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/estsoft/projectdose/fcm/dto/ApiResponseWrapper.java
+++ b/src/main/java/com/estsoft/projectdose/fcm/dto/ApiResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.estsoft.projectdose.fcm.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ApiResponseWrapper<T> {
+	private int result;
+
+	private String resultCode;
+
+	private String resultMsg;
+
+	private T data;
+}

--- a/src/main/java/com/estsoft/projectdose/fcm/dto/FcmMessageDto.java
+++ b/src/main/java/com/estsoft/projectdose/fcm/dto/FcmMessageDto.java
@@ -1,0 +1,30 @@
+package com.estsoft.projectdose.fcm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FcmMessageDto {
+
+	private boolean validateOnly;
+	private FcmMessageDto.Message message;
+
+	@Builder
+	@AllArgsConstructor
+	@Getter
+	public static class Message {
+		private FcmMessageDto.Notification notification;
+		private String token;
+	}
+
+	@Builder
+	@AllArgsConstructor
+	@Getter
+	public static class Notification {
+		private String title;
+		private String body;
+		private String image;
+	}
+}

--- a/src/main/java/com/estsoft/projectdose/fcm/dto/FcmSendDto.java
+++ b/src/main/java/com/estsoft/projectdose/fcm/dto/FcmSendDto.java
@@ -1,0 +1,24 @@
+package com.estsoft.projectdose.fcm.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmSendDto {
+
+	private String token;
+	private String title;
+	private String body;
+
+	@Builder(toBuilder = true)
+	public FcmSendDto(String token, String title, String body) {
+		this.token = token;
+		this.title = title;
+		this.body = body;
+	}
+}

--- a/src/main/java/com/estsoft/projectdose/fcm/dto/SuccessCode.java
+++ b/src/main/java/com/estsoft/projectdose/fcm/dto/SuccessCode.java
@@ -1,5 +1,8 @@
 package com.estsoft.projectdose.fcm.dto;
 
+import lombok.Getter;
+
+@Getter
 public enum SuccessCode {
 
 	SELECT_SUCCESS("200", "Successfully fetched data"),
@@ -13,11 +16,4 @@ public enum SuccessCode {
 		this.message = message;
 	}
 
-	public String getStatus() {
-		return status;
-	}
-
-	public String getMessage() {
-		return message;
-	}
 }

--- a/src/main/java/com/estsoft/projectdose/fcm/dto/SuccessCode.java
+++ b/src/main/java/com/estsoft/projectdose/fcm/dto/SuccessCode.java
@@ -1,0 +1,23 @@
+package com.estsoft.projectdose.fcm.dto;
+
+public enum SuccessCode {
+
+	SELECT_SUCCESS("200", "Successfully fetched data"),
+	OPERATION_SUCCESS("200", "Operation was successful");
+
+	private final String status;
+	private final String message;
+
+	SuccessCode(String status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/com/estsoft/projectdose/fcm/service/FcmService.java
+++ b/src/main/java/com/estsoft/projectdose/fcm/service/FcmService.java
@@ -1,0 +1,10 @@
+package com.estsoft.projectdose.fcm.service;
+
+import java.io.IOException;
+
+import com.estsoft.projectdose.fcm.dto.FcmSendDto;
+
+public interface FcmService {
+
+	int sendMessageTo(FcmSendDto fcmSendDto) throws IOException;
+}

--- a/src/main/java/com/estsoft/projectdose/fcm/service/impl/FcmServiceImpl.java
+++ b/src/main/java/com/estsoft/projectdose/fcm/service/impl/FcmServiceImpl.java
@@ -1,0 +1,87 @@
+package com.estsoft.projectdose.fcm.service.impl;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.*;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+
+import com.estsoft.projectdose.fcm.dto.FcmMessageDto;
+import com.estsoft.projectdose.fcm.dto.FcmSendDto;
+import com.estsoft.projectdose.fcm.service.FcmService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class FcmServiceImpl implements FcmService {
+
+	@Override
+	public int sendMessageTo(FcmSendDto fcmSendDto) throws IOException {
+		System.out.println("fcmSendDto :: " + fcmSendDto.toString());
+		String message = makeMessage(fcmSendDto);
+		RestTemplate restTemplate = new RestTemplate();
+
+		restTemplate.getMessageConverters()
+			.add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("Authorization", "Bearer " + getAccessToken());
+
+		HttpEntity<String> entity = new HttpEntity<>(message, headers);
+
+		String API_URL = "https://fcm.googleapis.com/v1/projects/project-dose/messages:send";
+		ResponseEntity<String> response = null;
+		try {
+			restTemplate.exchange(API_URL, HttpMethod.POST, entity, String.class);
+			System.out.println(response.getStatusCode());
+			return response.getStatusCode() == HttpStatus.OK ? 1 : 0;
+		} catch (Exception e) {
+			log.error("[-] FCM 전송 오류 :: " + e.getMessage());
+			log.error("[-] 오류 발생 토큰 :: [" + fcmSendDto.getToken() + "]");
+			log.error("[-] 오류 발생 메시지 :: [" + fcmSendDto.getBody() + "]");
+			return 0;
+		}
+	}
+
+	private String getAccessToken() throws IOException {
+		String firebaseConfigPath = "firebase/project-dose-firebase-key.json";
+
+		GoogleCredentials googleCredentials = GoogleCredentials
+			.fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+			.createScoped(List.of("<https://www.googleapis.com/auth/cloud-platform>"));
+
+		googleCredentials.refreshIfExpired();
+		return googleCredentials.getAccessToken().getTokenValue();
+	}
+
+	private String makeMessage(FcmSendDto fcmSendDto) throws JsonProcessingException {
+
+		ObjectMapper om = new ObjectMapper();
+		FcmMessageDto fcmMessageDto = FcmMessageDto
+			.builder()
+			.message(FcmMessageDto.Message.builder()
+				.token(fcmSendDto.getToken())
+				.notification(FcmMessageDto.Notification.builder()
+					.title(fcmSendDto.getTitle())
+					.body(fcmSendDto.getBody())
+					.image(null)
+					.build()
+				).build())
+			.validateOnly(false)
+			.build();
+
+		return om.writeValueAsString(fcmMessageDto);
+	}
+}
+
+


### PR DESCRIPTION
## 🔎 작업 내용
FcmController.java
- /api/v1/fcm/sendMessage 는 FCM 메시지를 보내는 api

ApiResponseWrapper.java
- FcmController에서 pushMessage를 수행하기 위한 dto
- pushMessage는 결과 코드, 상태 코드, 상태 메시지를 포함함

FcmMessageDto.java
- FCM 메시지의 구조를 설정하는 dto

FcmSendDto.java
- FCM 메시지의 정보(FCM 토큰, 제목, 본문)를 구성하는 dto

SuccessCode.java
- FcmController의 pushMessage에서 표현할 상태 코드와 상태 메시지를 담당

FcmServiceimpl.java
- sendMessageTo는 FcmSendDto를 통해 푸시 메시지의 데이터 수신
- makeMessage는 FcmMessageDto 형태로 FCM 메시지 구조 형성 후 JSON 형식으로 변환
- RestTemplate는 FCM 서버에 POST 요청, 헤더에는 Authorization 토큰 포함, 성공 여부에 따라 1 또는 0 반환
- getAccessToken은 firebase 계정을 사용해 FCM API에 접근 가능한 액세스 토큰 획득,
  firebase 키 파일을 통해 Google 인증 처리, cloud-platform을 설정하고 인증 마친 후 액세스 토큰 반환

FcmService.java
- 서비스의 핵심 코드를 유지보수성과 확장성을 위해 implements로 FcmServiceimpl로 분리

build.gradle
- firebase admin sdk
- google auth library
- slf4j logger
- Jackson Data Bind
<br/>

## ➕ 이슈 링크

> #이슈번호

<br/>

## 이미지 첨부 (선택)

<br/>